### PR TITLE
Proper keyboard interrupt handling.

### DIFF
--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -11,7 +11,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 # Expected name of the JAR file.
 JAR_NAME = 'cromwell.jar'
@@ -21,7 +21,8 @@ PKG_NAME = 'cromwell'
 DEFAULT_JVM_MEM_OPTS = ('-Xms512m', '-Xmx1g')
 
 
-def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
+def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS
+             ) -> Tuple[List[str], List[str], List[str]]:
     """Constructs a list of Java arguments based on our argument list.
 
 
@@ -34,12 +35,11 @@ def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
 
     for arg in argv:
         if arg.startswith('-D') or arg.startswith('-XX'):
-            opts_list = prop_opts
+            prop_opts.append(arg)
         elif arg.startswith('-Xm'):
-            opts_list = mem_opts
+            mem_opts.append(arg)
         else:
-            opts_list = pass_args
-        opts_list.append(arg)
+            pass_args.append(arg)
 
     if mem_opts == [] and os.getenv('_JAVA_OPTIONS') is None:
         mem_opts = list(default_mem_opts)
@@ -52,7 +52,7 @@ def main():
     prefix = script.parent.parent      # Script is in prefix/bin/script.
     jar_path = Path(prefix, "share", PKG_NAME, JAR_NAME)
 
-    (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
+    mem_opts, prop_opts, pass_args = jvm_opts(sys.argv[1:])
 
     if pass_args != [] and pass_args[0].startswith('org'):
         jar_arg = '-cp'

--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Wrapper script for invoking the jar.
 #

--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -21,27 +21,6 @@ PKG_NAME = 'cromwell'
 DEFAULT_JVM_MEM_OPTS = ('-Xms512m', '-Xmx1g')
 
 
-def jar_dir_from_bin_file(in_path: Path) -> Path:
-    """Returns the path to the JAR file"""
-    full_path = in_path.resolve()  # x/x/bin/my_script
-    # go to x/x/share/PKG_name
-    jar_path = full_path.parent.parent / "share" / PKG_NAME
-    return jar_path
-
-
-def java_executable() -> Path:
-    """Returns the name of the Java executable."""
-    java_home = os.getenv('JAVA_HOME')
-    java_bin = Path('bin', 'java')
-    env_prefix = jar_dir_from_bin_file(Path(sys.argv[0])).parent.parent
-
-    if java_home and os.access(str(Path(java_home, java_bin)), os.X_OK):
-        return Path(java_home, java_bin)
-    else:
-        # Use Java installed with Anaconda to ensure correct version
-        return env_prefix / 'bin' / 'java'
-
-
 def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
     """Constructs a list of Java arguments based on our argument list.
 
@@ -69,8 +48,10 @@ def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
 
 
 def main():
-    java = java_executable()
-    jar_dir = jar_dir_from_bin_file(Path(sys.argv[0]))
+    script = Path(sys.argv[0])
+    prefix = script.parent.parent      # Script is in prefix/bin/script.
+    jar_path = Path(prefix, "share", PKG_NAME, JAR_NAME)
+
     (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
 
     if pass_args != [] and pass_args[0].startswith('org'):
@@ -78,8 +59,7 @@ def main():
     else:
         jar_arg = '-jar'
 
-    jar_path = jar_dir / JAR_NAME
-    java_args: List[str] = ([java] + mem_opts + prop_opts +
+    java_args: List[str] = (["java"] + mem_opts + prop_opts +
                             [jar_arg] + [str(jar_path)] + pass_args)
     sys.exit(subprocess.call(java_args))
 

--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -48,7 +48,7 @@ def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS
 
 
 def main():
-    script = Path(sys.argv[0]).resolve()
+    script = Path(sys.argv[0]).resolve()  # Handle symlinks and .. dirs.
     prefix = script.parent.parent      # Script is in prefix/bin/script.
     jar_path = Path(prefix, "share", PKG_NAME, JAR_NAME)
 

--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Wrapper script for invoking the jar.
 #
@@ -10,8 +10,6 @@
 import os
 import subprocess
 import sys
-from pathlib import Path
-from typing import List, Tuple
 
 # Expected name of the JAR file.
 JAR_NAME = 'cromwell.jar'
@@ -21,8 +19,7 @@ PKG_NAME = 'cromwell'
 DEFAULT_JVM_MEM_OPTS = ('-Xms512m', '-Xmx1g')
 
 
-def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS
-             ) -> Tuple[List[str], List[str], List[str]]:
+def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
     """Constructs a list of Java arguments based on our argument list.
 
 
@@ -48,9 +45,10 @@ def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS
 
 
 def main():
-    script = Path(sys.argv[0]).resolve()  # Handle symlinks and .. dirs.
-    prefix = script.parent.parent      # Script is in prefix/bin/script.
-    jar_path = Path(prefix, "share", PKG_NAME, JAR_NAME)
+    script = os.path.realpath(sys.argv[0])  # Handle symlinks and .. dirs.
+    # Script is in prefix/bin/script.
+    prefix = os.path.dirname(os.path.dirname(script))
+    jar_path = os.path.join(prefix, "share", PKG_NAME, JAR_NAME)
 
     mem_opts, prop_opts, pass_args = jvm_opts(sys.argv[1:])
 
@@ -59,8 +57,8 @@ def main():
     else:
         jar_arg = '-jar'
 
-    java_args: List[str] = (["java"] + mem_opts + prop_opts +
-                            [jar_arg] + [str(jar_path)] + pass_args)
+    java_args = (["java"] + mem_opts + prop_opts + [jar_arg] + [jar_path] +
+                 pass_args)
 
     with subprocess.Popen(java_args) as process:
         # This code is adapted from python's stdlib subprocess.run code.

--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -61,7 +61,21 @@ def main():
 
     java_args: List[str] = (["java"] + mem_opts + prop_opts +
                             [jar_arg] + [str(jar_path)] + pass_args)
-    sys.exit(subprocess.call(java_args))
+
+    with subprocess.Popen(java_args) as process:
+        # This code is adapted from python's stdlib subprocess.run code.
+        try:
+            process.communicate()  # Waits until the program is finished.
+        except KeyboardInterrupt:
+            # In case of keyboard interrupt we gracefully shutdown Cromwell.
+            process.terminate()
+            process.wait()
+            raise
+        except:
+            process.kill()
+            process.wait()
+        retcode = process.poll()
+    sys.exit(retcode)
 
 
 if __name__ == "__main__":

--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -48,7 +48,7 @@ def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS
 
 
 def main():
-    script = Path(sys.argv[0])
+    script = Path(sys.argv[0]).resolve()
     prefix = script.parent.parent      # Script is in prefix/bin/script.
     jar_path = Path(prefix, "share", PKG_NAME, JAR_NAME)
 

--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -18,7 +18,7 @@ JAR_NAME = 'cromwell.jar'
 PKG_NAME = 'cromwell'
 
 # Default options passed to the `java` executable.
-DEFAULT_JVM_MEM_OPTS = ['-Xms512m', '-Xmx1g']
+DEFAULT_JVM_MEM_OPTS = ('-Xms512m', '-Xmx1g')
 
 
 def real_dirname(in_path):
@@ -39,6 +39,7 @@ def java_executable():
     else:
         # Use Java installed with Anaconda to ensure correct version
         return os.path.join(env_prefix, 'bin', 'java')
+
 
 def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
     """Constructs a list of Java arguments based on our argument list.
@@ -61,9 +62,9 @@ def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
         opts_list.append(arg)
 
     if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
-        mem_opts = default_mem_opts
+        mem_opts = list(default_mem_opts)
 
-    return (mem_opts, prop_opts, pass_args)
+    return mem_opts, prop_opts, pass_args
 
 
 def main():

--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -7,15 +7,13 @@
 # the peptide-shaker wrapper
 # (https://github.com/bioconda/bioconda-recipes/blob/master/recipes/peptide-shaker/peptide-shaker.py)
 
+import os
 import subprocess
 import sys
-import os
-
 from pathlib import Path
-
-# Expected name of the JAR file.
 from typing import List
 
+# Expected name of the JAR file.
 JAR_NAME = 'cromwell.jar'
 PKG_NAME = 'cromwell'
 

--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -19,6 +19,16 @@ PKG_NAME = 'cromwell'
 DEFAULT_JVM_MEM_OPTS = ('-Xms512m', '-Xmx1g')
 
 
+def java_executable(env_prefix):
+    """Returns the name of the Java executable."""
+    java_home = os.getenv('JAVA_HOME')
+    if java_home:
+        java_home_bin = os.path.join(java_home, 'bin', 'java')
+        if os.access(java_home_bin, os.X_OK):
+            return java_home_bin
+    return os.path.join(env_prefix, 'bin', 'java')
+
+
 def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
     """Constructs a list of Java arguments based on our argument list.
 
@@ -48,6 +58,7 @@ def main():
     script = os.path.realpath(sys.argv[0])  # Handle symlinks and .. dirs.
     # Script is in prefix/bin/script.
     prefix = os.path.dirname(os.path.dirname(script))
+    java = java_executable(prefix)  # Make sure java from prefix (not system) is used.
     jar_path = os.path.join(prefix, "share", PKG_NAME, JAR_NAME)
 
     mem_opts, prop_opts, pass_args = jvm_opts(sys.argv[1:])
@@ -57,8 +68,7 @@ def main():
     else:
         jar_arg = '-jar'
 
-    java_args = (["java"] + mem_opts + prop_opts + [jar_arg] + [jar_path] +
-                 pass_args)
+    java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args
 
     with subprocess.Popen(java_args) as process:
         # This code is adapted from python's stdlib subprocess.run code.

--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -78,7 +78,6 @@ def main():
             # In case of keyboard interrupt we gracefully shutdown Cromwell.
             process.terminate()
             process.wait()
-            raise
         except:
             process.kill()
             process.wait()

--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -81,6 +81,7 @@ def main():
         except:
             process.kill()
             process.wait()
+            raise
         retcode = process.poll()
     sys.exit(retcode)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   # Cannot build on Windows because findutils is not available
   skip: true  # [win]
-  number: 0
+  number: 1
 
 requirements:
   run:

--- a/recipe/womtool.py
+++ b/recipe/womtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Wrapper script for invoking the jar.
 #
@@ -10,8 +10,6 @@
 import os
 import subprocess
 import sys
-from pathlib import Path
-from typing import List, Tuple
 
 # Expected name of the JAR file.
 JAR_NAME = 'womtool.jar'
@@ -21,8 +19,7 @@ PKG_NAME = 'cromwell'
 DEFAULT_JVM_MEM_OPTS = ('-Xms512m', '-Xmx1g')
 
 
-def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS
-             ) -> Tuple[List[str], List[str], List[str]]:
+def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
     """Constructs a list of Java arguments based on our argument list.
 
 
@@ -48,9 +45,10 @@ def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS
 
 
 def main():
-    script = Path(sys.argv[0]).resolve()  # Handle symlinks and .. dirs.
-    prefix = script.parent.parent      # Script is in prefix/bin/script.
-    jar_path = Path(prefix, "share", PKG_NAME, JAR_NAME)
+    script = os.path.realpath(sys.argv[0])  # Handle symlinks and .. dirs.
+    # Script is in prefix/bin/script.
+    prefix = os.path.dirname(os.path.dirname(script))
+    jar_path = os.path.join(prefix, "share", PKG_NAME, JAR_NAME)
 
     mem_opts, prop_opts, pass_args = jvm_opts(sys.argv[1:])
 
@@ -59,8 +57,8 @@ def main():
     else:
         jar_arg = '-jar'
 
-    java_args: List[str] = (["java"] + mem_opts + prop_opts +
-                            [jar_arg] + [str(jar_path)] + pass_args)
+    java_args = (["java"] + mem_opts + prop_opts + [jar_arg] + [jar_path] +
+                 pass_args)
     sys.exit(subprocess.call(java_args))
 
 

--- a/recipe/womtool.py
+++ b/recipe/womtool.py
@@ -48,7 +48,7 @@ def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS
 
 
 def main():
-    script = Path(sys.argv[0]).resolve()
+    script = Path(sys.argv[0]).resolve()  # Handle symlinks and .. dirs.
     prefix = script.parent.parent      # Script is in prefix/bin/script.
     jar_path = Path(prefix, "share", PKG_NAME, JAR_NAME)
 

--- a/recipe/womtool.py
+++ b/recipe/womtool.py
@@ -19,6 +19,16 @@ PKG_NAME = 'cromwell'
 DEFAULT_JVM_MEM_OPTS = ('-Xms512m', '-Xmx1g')
 
 
+def java_executable(env_prefix):
+    """Returns the name of the Java executable."""
+    java_home = os.getenv('JAVA_HOME')
+    if java_home:
+        java_home_bin = os.path.join(java_home, 'bin', 'java')
+        if os.access(java_home_bin, os.X_OK):
+            return java_home_bin
+    return os.path.join(env_prefix, 'bin', 'java')
+
+
 def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
     """Constructs a list of Java arguments based on our argument list.
 
@@ -48,6 +58,7 @@ def main():
     script = os.path.realpath(sys.argv[0])  # Handle symlinks and .. dirs.
     # Script is in prefix/bin/script.
     prefix = os.path.dirname(os.path.dirname(script))
+    java = java_executable(prefix)  # Make sure java from prefix (not system) is used.
     jar_path = os.path.join(prefix, "share", PKG_NAME, JAR_NAME)
 
     mem_opts, prop_opts, pass_args = jvm_opts(sys.argv[1:])
@@ -57,8 +68,7 @@ def main():
     else:
         jar_arg = '-jar'
 
-    java_args = (["java"] + mem_opts + prop_opts + [jar_arg] + [jar_path] +
-                 pass_args)
+    java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args
     sys.exit(subprocess.call(java_args))
 
 

--- a/recipe/womtool.py
+++ b/recipe/womtool.py
@@ -48,7 +48,7 @@ def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS
 
 
 def main():
-    script = Path(sys.argv[0])
+    script = Path(sys.argv[0]).resolve()
     prefix = script.parent.parent      # Script is in prefix/bin/script.
     jar_path = Path(prefix, "share", PKG_NAME, JAR_NAME)
 

--- a/recipe/womtool.py
+++ b/recipe/womtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Wrapper script for invoking the jar.
 #
@@ -7,40 +7,22 @@
 # the peptide-shaker wrapper
 # (https://github.com/bioconda/bioconda-recipes/blob/master/recipes/peptide-shaker/peptide-shaker.py)
 
+import os
 import subprocess
 import sys
-import os
-from os import access, getenv, path, X_OK
-
+from pathlib import Path
+from typing import List, Tuple
 
 # Expected name of the JAR file.
 JAR_NAME = 'womtool.jar'
 PKG_NAME = 'cromwell'
 
 # Default options passed to the `java` executable.
-DEFAULT_JVM_MEM_OPTS = ['-Xms512m', '-Xmx1g']
+DEFAULT_JVM_MEM_OPTS = ('-Xms512m', '-Xmx1g')
 
 
-def real_dirname(in_path):
-    """Returns the path to the JAR file"""
-    realPath = os.path.dirname(os.path.realpath(in_path))
-    newPath = os.path.realpath(os.path.join(realPath, "..", "share", PKG_NAME))
-    return newPath
-
-
-def java_executable():
-    """Returns the name of the Java executable."""
-    java_home = getenv('JAVA_HOME')
-    java_bin = path.join('bin', 'java')
-    env_prefix = os.path.dirname(os.path.dirname(real_dirname(sys.argv[0])))
-
-    if java_home and access(os.path.join(java_home, java_bin), X_OK):
-        return os.path.join(java_home, java_bin)
-    else:
-        # Use Java installed with Anaconda to ensure correct version
-        return os.path.join(env_prefix, 'bin', 'java')
-
-def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
+def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS
+             ) -> Tuple[List[str], List[str], List[str]]:
     """Constructs a list of Java arguments based on our argument list.
 
 
@@ -53,31 +35,32 @@ def jvm_opts(argv, default_mem_opts=DEFAULT_JVM_MEM_OPTS):
 
     for arg in argv:
         if arg.startswith('-D') or arg.startswith('-XX'):
-            opts_list = prop_opts
+            prop_opts.append(arg)
         elif arg.startswith('-Xm'):
-            opts_list = mem_opts
+            mem_opts.append(arg)
         else:
-            opts_list = pass_args
-        opts_list.append(arg)
+            pass_args.append(arg)
 
-    if mem_opts == [] and getenv('_JAVA_OPTIONS') is None:
-        mem_opts = default_mem_opts
+    if mem_opts == [] and os.getenv('_JAVA_OPTIONS') is None:
+        mem_opts = list(default_mem_opts)
 
-    return (mem_opts, prop_opts, pass_args)
+    return mem_opts, prop_opts, pass_args
 
 
 def main():
-    java = java_executable()
-    jar_dir = real_dirname(sys.argv[0])
-    (mem_opts, prop_opts, pass_args) = jvm_opts(sys.argv[1:])
+    script = Path(sys.argv[0])
+    prefix = script.parent.parent      # Script is in prefix/bin/script.
+    jar_path = Path(prefix, "share", PKG_NAME, JAR_NAME)
+
+    mem_opts, prop_opts, pass_args = jvm_opts(sys.argv[1:])
 
     if pass_args != [] and pass_args[0].startswith('org'):
         jar_arg = '-cp'
     else:
         jar_arg = '-jar'
 
-    jar_path = path.join(jar_dir, JAR_NAME)
-    java_args = [java] + mem_opts + prop_opts + [jar_arg] + [jar_path] + pass_args
+    java_args: List[str] = (["java"] + mem_opts + prop_opts +
+                            [jar_arg] + [str(jar_path)] + pass_args)
     sys.exit(subprocess.call(java_args))
 
 


### PR DESCRIPTION
Using cromwell with the jar `java -jar cromwell.jar`, keyboard interrupts will gracefully shut down cromwell, terminating all the jobs etc. Unfortunately the current wrapper just kills cromwell on keyboard interrupt. This is annoying especially if cromwell leaves docker containers or cluster jobs running. 

I have updated the wrapper to terminate instead of kill on keyboard interrupt.

~~Furthermore since python2 is deprecated I have updated the script to use python3 pathlib.~~ EDIT: It turns out that editing the meta.yaml to use `python >=3` will give linting errors. After the simplification of the code it turns out that the number of required os.path calls is really limited. So I use os.path again to ensure backwards compatibility with python2.

~I have also eliminated some unnecessary code paths that detect the java executable. OpenJDK is part of this recipe, so `java` should be in `PATH`. There is no reason to have complicated code looking for the executable.~ This has been reversed, as the script should use java from the prefix, not system's java.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
