### PR TITLE
Fix bug in python2 implementation of the script

### DIFF
--- a/recipe/cromwell.py
+++ b/recipe/cromwell.py
@@ -11,6 +11,10 @@ import os
 import subprocess
 import sys
 
+if sys.version_info.major == 2:
+    # Backported subprocess is needed as it makes Popen a context manager.
+    import subprocess32 as subprocess
+
 # Expected name of the JAR file.
 JAR_NAME = 'cromwell.jar'
 PKG_NAME = 'cromwell'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - openjdk >=8,<9
     - python
     - findutils
-    - subprocess32  # [py27]
+    - subprocess32  # [py==27]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,13 +15,14 @@ source:
 build:
   # Cannot build on Windows because findutils is not available
   skip: true  # [win]
-  number: 0
+  number: 1
 
 requirements:
   run:
     - openjdk >=8,<9
     - python
     - findutils
+    - subprocess32  # [py27]
 
 test:
   commands:


### PR DESCRIPTION
Hi, I encountered a bug in the python2 implementation of the script. In vanilla python2 `subprocess.Popen` is not a context manager. Unfortunately when I tested it I was using Debian's python2 which has apparently already patched this by default. I tested with conda python2 now, and included the necessary subprocess32 dependency for python2.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
